### PR TITLE
docs: fix wrong shortcut usage

### DIFF
--- a/docs/developers/development-setup/dev-container.mdx
+++ b/docs/developers/development-setup/dev-container.mdx
@@ -21,7 +21,7 @@ To use the dev container for the Activepieces project, follow these steps:
 
 1. Clone the Activepieces repository to your local machine.
 2. Open the project in Visual Studio Code.
-3. Press `Ctrl+P` and type `> Dev Containers: Reopen in Container`.
+3. Press `Ctrl+Shift+P` and type `> Dev Containers: Reopen in Container`.
 4. Run `npm start`.
 5. The backend will run at `localhost:3000` and the frontend will run at `localhost:4200`.
 


### PR DESCRIPTION
Ctrl+P in VSCode is used to search across the files and Ctrl+Shift+P is what brings up the command palette.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

